### PR TITLE
POC: Display keys using the new address format

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "js-base64": "^3.7.2",
     "moment": "^2.29.3",
     "moment-timezone": "^0.5.34",
+    "multibase": "^4.0.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",

--- a/src/App.css
+++ b/src/App.css
@@ -373,6 +373,46 @@ h3.ant-typography .count, h4.ant-typography .count {
   cursor: pointer;
 }
 
+.key .ant-typography {
+  line-height: 14px;
+  padding: 5px 11px 6px;
+}
+
+.key .key-type {
+  font-size: 12px !important;
+}
+
+.key .key-text {
+  font-size: 13px !important;
+}
+
+.key .key-type.ant-typography, .key .key-type .ant-select-selector, .type-radio .ant-radio-button-wrapper-checked.type-ASCII, .type-radio .ant-radio-button-wrapper-checked.type-ASCII:hover, .type-radio .ant-radio-button-wrapper-checked.type-ASCII:not(.ant-radio-button-wrapper-disabled)::before {
+  background: #e6f7ff !important;
+  border: 1px solid #91d5ff !important;
+  color: #096dd9 !important;
+}
+
+.key .key-type .ant-select-arrow {
+  color: #096dd9 !important;
+  font-size: 8px !important;
+  margin-top: -5px;
+}
+
+.key .key-type .ant-select-selection-item {
+  padding-right: 18px !important;
+}
+
+.key .key-text {
+  font-family: 'IBM Plex Mono', Monaco, Menlo, Consolas, 'Courier New', monospace !important;
+  background: #FFF;
+  word-break: break-all;
+  overflow: hidden;
+}
+
+.ant-table .key .key-text {
+  border-left-width: 0 !important;
+}
+
 .type-radio .ant-radio-button-wrapper:hover {
   color: rgba(0, 0, 0, 0.65) !important;
 }

--- a/src/components/common/Key.js
+++ b/src/components/common/Key.js
@@ -132,15 +132,15 @@ const Key = props => {
             : props.type ?
                 <span><Tag color="blue" style={{textTransform: "uppercase"}}>{props.type}</Tag><Text className="code" copyable>{address}</Text></span>
             :
-                <Input.Group compact>
-                    <Select defaultValue="unknown" onChange={handleChange}>
-                        <Select.Option value="unknown">Unknown</Select.Option>
+                <Input.Group compact className={"key"}>
+                    <Select defaultValue="raw" size="small" className="key-type" onChange={handleChange}>
+                        <Select.Option value="raw">Raw</Select.Option>
                         <Select.Option value="ed25519">ED25519</Select.Option>
                         <Select.Option value="rcd1">RCD1</Select.Option>
                         <Select.Option value="btc">BTC</Select.Option>
                         <Select.Option value="eth">ETH</Select.Option>
                     </Select>
-                    <Text className="code" copyable>{address}</Text>
+                    <Text className="key-text" copyable>{address}</Text>
                 </Input.Group>
             }
         </div>

--- a/src/components/common/Key.js
+++ b/src/components/common/Key.js
@@ -1,0 +1,150 @@
+import { Alert, Input, Select, Skeleton, Tag, Typography } from "antd";
+import { useEffect, useState } from "react";
+import { encode, encoding } from "multibase";
+
+const { Text } = Typography;
+
+async function doChecksum(...parts) {
+    const c = await crypto.subtle.digest('SHA-256', Buffer.concat(parts));
+    return Buffer.from(await crypto.subtle.digest('SHA-256', c));
+}
+
+async function formatMH(hash) {
+    const checksum = (await doChecksum(Buffer.from('MH', 'utf-8'), hash)).slice(0, 4);
+    const encoded = encode('base58btc', Buffer.concat([hash, checksum]));
+    return 'MH' + Buffer.from(encoded).toString('utf-8');
+}
+
+async function formatAC1(hash) {
+    const checksum = (await doChecksum(Buffer.from('AC1', 'utf-8'), hash)).slice(0, 4);
+    const encoded = encoding('base58btc').encode(Buffer.concat([hash, checksum]));
+    return 'AC1' + Buffer.from(encoded).toString('utf-8');
+}
+
+function formatFA(hash) {
+    return formatWithPrefix(Buffer.from([0x5f, 0xb1]), hash);
+}
+
+async function formatBTC(hash) {
+    return 'BT' + await formatWithPrefix(Buffer.from([0x00]), hash);
+}
+
+async function formatETH(hash) {
+    if (hash.length > 20) {
+        hash = hash.slice(0, 20);
+    }
+    return '0x' + hash.toString('hex');
+}
+
+async function formatWithPrefix(prefix, hash) {
+    const checksum = (await doChecksum(prefix, hash)).slice(0, 4);
+    const encoded = encoding('base58btc').encode(Buffer.concat([prefix, hash, checksum]))
+    return Buffer.from(encoded).toString('utf-8');
+}
+
+const Key = props => {
+
+    const [address, setAddress] = useState(null);
+    const [error, setError] = useState(null);
+
+    const getAddress = async () => {
+        try {
+            let hashRaw;
+            if (props.publicKey) {
+                const keyRaw = Buffer.from(props.publicKey, 'hex');
+                hashRaw = Buffer.from(await crypto.subtle.digest('SHA-256', keyRaw));
+            } else {
+                hashRaw = Buffer.from(props.keyHash, 'hex');
+            }
+
+            switch (props.type) {
+                case 'ed25519':
+                case 'legacyED25519':
+                    setAddress(await formatAC1(hashRaw));
+                    break;
+                case 'rcd1':
+                    setAddress(await formatFA(hashRaw));
+                    break;
+                case 'btc':
+                case 'btclegacy':
+                    setAddress(await formatBTC(hashRaw));
+                    break;
+                case 'eth':
+                    setAddress(await formatETH(hashRaw));
+                    break;
+                default:
+                    setAddress(await formatMH(hashRaw));
+                    break;
+            }
+
+        } catch (error) {
+            setError(error.message);
+        }
+    }
+
+    const handleChange = async event => {
+        try {
+            setError(null);
+            let hashRaw;
+            if (props.publicKey) {
+                const keyRaw = Buffer.from(props.publicKey, 'hex');
+                hashRaw = Buffer.from(await crypto.subtle.digest('SHA-256', keyRaw));
+            } else {
+                hashRaw = Buffer.from(props.keyHash, 'hex');
+            }
+
+            switch (event) {
+                case 'ed25519':
+                    setAddress(await formatAC1(hashRaw));
+                    break;
+                case 'rcd1':
+                    setAddress(await formatFA(hashRaw));
+                    break;
+                case 'btc':
+                    setAddress(await formatBTC(hashRaw));
+                    break;
+                case 'eth':
+                    setAddress(await formatETH(hashRaw));
+                    break;
+                default:
+                    setAddress(await formatMH(hashRaw));
+                    break;
+            }
+        } catch (error) {
+            setError(error.message);
+        }
+    }
+
+    useEffect(() => {
+        getAddress()
+    }, []);
+
+    return (
+        <div>
+            {error ?
+                <div className="skeleton-holder">
+                    <Alert message={error} type="error" showIcon />
+                </div>
+            : !address ?
+                <div className="skeleton-holder">
+                    <Skeleton active />
+                </div>
+            : props.type ?
+                <span><Tag color="blue" style={{textTransform: "uppercase"}}>{props.type}</Tag><Text className="code" copyable>{address}</Text></span>
+            :
+                <Input.Group compact>
+                    <Select defaultValue="unknown" onChange={handleChange}>
+                        <Select.Option value="unknown">Unknown</Select.Option>
+                        <Select.Option value="ed25519">ED25519</Select.Option>
+                        <Select.Option value="rcd1">RCD1</Select.Option>
+                        <Select.Option value="btc">BTC</Select.Option>
+                        <Select.Option value="eth">ETH</Select.Option>
+                    </Select>
+                    <Text className="code" copyable>{address}</Text>
+                </Input.Group>
+            }
+        </div>
+    );
+}
+
+export default Key;

--- a/src/components/explorer/Acc/KeyPage.js
+++ b/src/components/explorer/Acc/KeyPage.js
@@ -18,6 +18,7 @@ import {
 import Count from '../../common/Count';
 import tooltipDescs from '../../common/TooltipDescriptions';
 import TxChain from '../../common/TxChain';
+import Key from '../../common/Key';
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -105,7 +106,7 @@ const KeyPage = props => {
                             dataSource={keypage.data.keys}
                             renderItem={item =>
                                 <List.Item>
-                                    {item.publicKey ? <span><Tag color="blue">SHA256</Tag><Text className="code" copyable>{item.publicKey}</Text></span> : null }
+                                    {item.publicKey ? <Key keyHash={item.publicKey} /> : null}
                                     {item.delegate ? <span><Tag color="green">Delegate</Tag><Link to={'/acc/' + item.delegate.replace("acc://", "")}><IconContext.Provider value={{ className: 'react-icons' }}><RiAccountBoxLine /></IconContext.Provider>{item.delegate}</Link></span> : null }
                                 </List.Item>
                             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@multiformats/base-x@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
+  integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -7764,6 +7769,13 @@ ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+multibase@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.6.tgz#6e624341483d6123ca1ede956208cb821b440559"
+  integrity sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==
+  dependencies:
+    "@multiformats/base-x" "^4.0.1"
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Adds a module that displays key hashes with the address format defined in AIP-001.

![image](https://user-images.githubusercontent.com/879055/209221303-98263ce6-7f54-4ef4-9a3c-65d500ff1238.png)

Note, I added support for `<Key publicKey={...} type={...} />` specifically for signatures. Currently it isn't used, but I do want to update #38 to use this module.