### PR TITLE
Fix multihash addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "js-base64": "^3.7.2",
     "moment": "^2.29.3",
     "moment-timezone": "^0.5.34",
-    "multibase": "^4.0.6",
+    "multiformats": "^11.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",

--- a/src/components/common/Key.js
+++ b/src/components/common/Key.js
@@ -1,6 +1,7 @@
 import { Alert, Input, Select, Skeleton, Tag, Typography } from "antd";
 import { useEffect, useState } from "react";
-import { encode, encoding } from "multibase";
+import { base58btc } from "multiformats/src/bases/base58";
+import { identity } from "multiformats/src/hashes/identity";
 
 const { Text } = Typography;
 
@@ -10,14 +11,15 @@ async function doChecksum(...parts) {
 }
 
 async function formatMH(hash) {
-    const checksum = (await doChecksum(Buffer.from('MH', 'utf-8'), hash)).slice(0, 4);
-    const encoded = encode('base58btc', Buffer.concat([hash, checksum]));
+    const digested = Buffer.from(identity.digest(hash).bytes);
+    const checksum = (await doChecksum(Buffer.from('MH', 'utf-8'), digested)).slice(0, 4);
+    const encoded = base58btc.encode(Buffer.concat([digested, checksum]));
     return 'MH' + Buffer.from(encoded).toString('utf-8');
 }
 
 async function formatAC1(hash) {
     const checksum = (await doChecksum(Buffer.from('AC1', 'utf-8'), hash)).slice(0, 4);
-    const encoded = encoding('base58btc').encode(Buffer.concat([hash, checksum]));
+    const encoded = base58btc.baseEncode(Buffer.concat([hash, checksum]));
     return 'AC1' + Buffer.from(encoded).toString('utf-8');
 }
 
@@ -38,7 +40,7 @@ async function formatETH(hash) {
 
 async function formatWithPrefix(prefix, hash) {
     const checksum = (await doChecksum(prefix, hash)).slice(0, 4);
-    const encoded = encoding('base58btc').encode(Buffer.concat([prefix, hash, checksum]))
+    const encoded = base58btc.baseEncode(Buffer.concat([prefix, hash, checksum]))
     return Buffer.from(encoded).toString('utf-8');
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,11 +1446,6 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@multiformats/base-x@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
-  integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -7770,13 +7765,6 @@ ms@2.1.3, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multibase@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.6.tgz#6e624341483d6123ca1ede956208cb821b440559"
-  integrity sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==
-  dependencies:
-    "@multiformats/base-x" "^4.0.1"
-
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz#899f11d9686e5e05cb91b35d5f0e63b773cfc901"
@@ -7789,6 +7777,11 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+multiformats@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-11.0.1.tgz#ba58c3f69f032ab67dab4b48cc70f01ac2ca07fe"
+  integrity sha512-atWruyH34YiknSdL5yeIir00EDlJRpHzELYQxG7Iy29eCyL+VrZHpPrX5yqlik3jnuqpLpRKVZ0SGVb9UzKaSA==
 
 nan@^2.12.1:
   version "2.15.0"


### PR DESCRIPTION
The implementation of AIP-001 I provided in #39 was faulty. This PR fixes that implementation, and uses `multiformats` instead of `multibase`. The latter was deprecated and I needed multiformats anyways for the multihash implementation.